### PR TITLE
add validation to exclude ync meters for EVS2_NUS project scope

### DIFF
--- a/lib/pagrid_helper/project_helper/project_setting.dart
+++ b/lib/pagrid_helper/project_helper/project_setting.dart
@@ -159,7 +159,14 @@ final projectProfileRepo = [
       //8 digits, start with '1'
       RegExp exp = RegExp(r'^1\d{7}$');
       if (exp.hasMatch(displayname)) {
-        return null;
+        int displaynameInt = int.parse(displayname);
+        if (displaynameInt < 10002801 ||
+            displaynameInt > 10003925 ||
+            [10003963, 10003982, 10003985, 10009999].contains(displaynameInt)) {
+          return 'Invalid displayname';
+        } else {
+          return null;
+        }
       } else {
         return 'Invalid displayname';
       }

--- a/lib/pagrid_helper/project_helper/project_setting.dart
+++ b/lib/pagrid_helper/project_helper/project_setting.dart
@@ -164,9 +164,8 @@ final projectProfileRepo = [
             displaynameInt > 10003925 ||
             [10003963, 10003982, 10003985, 10009999].contains(displaynameInt)) {
           return 'Invalid displayname';
-        } else {
-          return null;
         }
+        return null;
       } else {
         return 'Invalid displayname';
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.12.0
+version: 2.12.1
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request includes changes to the `lib/pagrid_helper/project_helper/project_setting.dart` file and a version update in the `pubspec.yaml` file. The most important changes are as follows:

Validation improvements:

* [`lib/pagrid_helper/project_helper/project_setting.dart`](diffhunk://#diff-0e1a3ac231a298a20fab69550cdc4d957e0edccbe3b6416f2e453d52985b47e4R162-R167): Added additional validation for `displayname` to ensure it falls within a specific range and excludes certain values.

Version update:

* [`pubspec.yaml`](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3): Updated the package version from 2.12.0 to 2.12.1.