### PR TITLE
add comment

### DIFF
--- a/lib/pagrid_helper/project_helper/project_setting.dart
+++ b/lib/pagrid_helper/project_helper/project_setting.dart
@@ -450,6 +450,7 @@ String? nusSnValidator(String displayname) {
   RegExp exp = RegExp(r'^1\d{7}$');
   int displaynameInt = int.parse(displayname);
   if (exp.hasMatch(displayname)) {
+    //check if the meter is under YNC, if yes, return invalid displayname
     if ((displaynameInt >= 10002801 && displaynameInt <= 10003925) ||
         [10003963, 10003982, 10003985, 10009999].contains(displaynameInt)) {
       return 'Invalid displayname';


### PR DESCRIPTION
This pull request includes a change to the `nusSnValidator` function in the `project_setting.dart` file. The change adds a comment to clarify the purpose of a specific condition within the function.

* [`lib/pagrid_helper/project_helper/project_setting.dart`](diffhunk://#diff-0e1a3ac231a298a20fab69550cdc4d957e0edccbe3b6416f2e453d52985b47e4R453): Added a comment to explain that the condition checks if the meter is under YNC, and if so, returns 'Invalid displayname'.