### PR TITLE
add return value to nus validator

### DIFF
--- a/lib/pagrid_helper/project_helper/project_setting.dart
+++ b/lib/pagrid_helper/project_helper/project_setting.dart
@@ -157,7 +157,7 @@ final projectProfileRepo = [
     'currency': 'SGD',
     'validate_entity_displayname': (displayname) {
       //8 digits, start with '1'
-      nusSnValidator(displayname);
+      return nusSnValidator(displayname);
     },
     'payment_mode_setting': {
       {


### PR DESCRIPTION
This pull request includes a small change to the `project_setting.dart` file. The change ensures that the `validate_entity_displayname` function returns the result of `nusSnValidator(displayname)`.

* [`lib/pagrid_helper/project_helper/project_setting.dart`](diffhunk://#diff-0e1a3ac231a298a20fab69550cdc4d957e0edccbe3b6416f2e453d52985b47e4L160-R160): Modified the `validate_entity_displayname` function to return the result of `nusSnValidator(displayname)`.