### PR TITLE
include option for cm manager

### DIFF
--- a/lib/pag_helper/def_helper/def_page_route.dart
+++ b/lib/pag_helper/def_helper/def_page_route.dart
@@ -203,6 +203,16 @@ enum PagPageRoute {
     'am_dashboard',
     Symbols.grid_view,
   ),
+  cmDashboard(
+    'Condition Minitoring',
+    'cm_dashboard',
+    Symbols.grid_view,
+  ),
+  cmManager(
+    'CM Manager',
+    'cm_manager',
+    Symbols.home_iot_device,
+  ),
   amScopeManager(
     'Scope Manager',
     'am_scope_manager',

--- a/lib/pag_helper/pag_app_context_list.dart
+++ b/lib/pag_helper/pag_app_context_list.dart
@@ -188,6 +188,20 @@ MdlPagAppContext appCtxQq = MdlPagAppContext(
     PagPageRoute.ctLab,
   ],
 );
+MdlPagAppContext appCtxCm = MdlPagAppContext(
+  name: 'cm',
+  label: 'Condition Monitoring',
+  shortLabel: 'CM',
+  route: 'cm_dashboard',
+  appContextType: PagAppContextType.cm,
+  routeType: PagAppRouteType.route,
+  // menuRouteList: [
+  //   getMenueItem(PagPageRoute.pqDashboard),
+  //   getMenueItem(PagPageRoute.pqInsights),
+  //   getMenueItem(PagPageRoute.ctLab)
+  // ],
+  routeList: [PagPageRoute.cmDashboard, PagPageRoute.cmManager],
+);
 // final PagAppContext ctlab = PagAppContext(
 //   name: 'ctlab',
 //   label: 'CT Lab',
@@ -228,6 +242,7 @@ final List<MdlPagAppContext> appContextList = [
   appCtxPtw,
   appCtxVm,
   appCtxBms,
+  appCtxCm,
   appCtxQq,
   appCtxEs,
   // ctlab,

--- a/lib/pag_helper/wgt/ls/wgt_ls_item_flexi.dart
+++ b/lib/pag_helper/wgt/ls/wgt_ls_item_flexi.dart
@@ -369,13 +369,16 @@ class _WgtListSearchItemFlexiState extends State<WgtListSearchItemFlexi> {
         widget.itemKind == PagItemKind.scope;
     bool isSoa = widget.listContextType == PagListContextType.soa;
     bool isPp = widget.listContextType == PagListContextType.paymentMatching;
+    bool isCmDeviceLs = widget.pagAppContext! == appCtxCm &&
+        widget.itemKind == PagItemKind.device;
     if (isEmsDeviceLs ||
         isEmsMeterUsage ||
         isEmsTenantUsage ||
         isEsInsights ||
         isBill ||
         isSoa ||
-        isPp) {
+        isPp ||
+        isCmDeviceLs) {
       addInfoColumn = false;
     }
     if (hasInfoColumn) {

--- a/lib/pag_helper/wgt/ls/wgt_ls_kind.dart
+++ b/lib/pag_helper/wgt/ls/wgt_ls_kind.dart
@@ -343,8 +343,10 @@ class _WgtListSearchKindState extends State<WgtListSearchKind> {
 
   @override
   Widget build(BuildContext context) {
-    bool enablePaneModeSwitcher = widget.pagAppContext == appCtxEms &&
-        widget.listContextType == PagListContextType.info;
+    bool enablePaneModeSwitcher = (widget.pagAppContext == appCtxEms &&
+        widget.listContextType == PagListContextType.info)||(widget.pagAppContext == appCtxCm &&
+        widget.listContextType == PagListContextType.info);
+        
     return SingleChildScrollView(
       child: Column(
         children: [

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.18.4
+version: 2.18.3
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces support for a new "Condition Monitoring" (CM) application context throughout the codebase. The main changes add new routes and context objects for CM, update UI logic to handle CM-specific cases, and ensure CM is included in the list of available app contexts.

**Condition Monitoring (CM) context integration:**

* Added new `cmDashboard` and `cmManager` routes to the `PagPageRoute` enum to support CM navigation.
* Created a new `appCtxCm` context in `pag_app_context_list.dart` for Condition Monitoring, with appropriate labels, route, and route list.
* Included `appCtxCm` in the global `appContextList` so that the CM context is recognized by the application.

**UI logic updates for CM:**

* Updated `_WgtListSearchItemFlexiState` to disable the info column for CM device lists, matching the behavior of other contexts.
* Modified `_WgtListSearchKindState` to enable the pane mode switcher for the CM context when in "info" list context, similar to EMS.

**Other:**

* Downgraded the package version in `pubspec.yaml` from 2.18.4 to 2.18.3.