### PR TITLE
add support for sensor type - cm

### DIFF
--- a/lib/pag_helper/wgt/history_presentor/wgt_pag_item_history_getter.dart
+++ b/lib/pag_helper/wgt/history_presentor/wgt_pag_item_history_getter.dart
@@ -284,7 +284,7 @@ class _WgtPagItemHistoryGetterState extends State<WgtPagItemHistoryGetter> {
 
       queryMap = {
         'scope': widget.loggedInUser.selectedScope.toScopeMap(),
-        'item_type': itemTypeStr,
+        'item_type': itemTypeStr=="" ? widget.itemType?.value : itemTypeStr,
         'item_id_type': widget.itemIdType.name,
         'item_id_value': widget.itemId,
         'history_type': widget.historyType.name,
@@ -323,6 +323,8 @@ class _WgtPagItemHistoryGetterState extends State<WgtPagItemHistoryGetter> {
           operation: '',
         ),
       );
+
+      queryMap["item_type"] = itemTypeStr;
 
       var itemHistoryInfo = data['item_history'];
 

--- a/lib/pag_helper/wgt/history_presentor/wgt_pag_item_history_presenter.dart
+++ b/lib/pag_helper/wgt/history_presentor/wgt_pag_item_history_presenter.dart
@@ -359,16 +359,36 @@ class _WgtPagItemHistoryPresenterState
               SensorType.light ||
               SensorType.co2 ||
               SensorType.fan ||
+              SensorType.temperature_humidity ||
               SensorType.switchSensor:
           _selectedChartReadingTypeKey = 'val_sensor';
-
+           String valColName = "val";
+              switch(widget.itemSubType) {
+                  case SensorType.temperature || SensorType.temperature_humidity:
+                    valColName = "temperature_val";
+                    break;
+                  case SensorType.humidity:
+                    valColName = "humidity_val";
+                    break;
+                  case SensorType.ir:
+                    valColName = "ir_val";
+                    break;
+                  case SensorType.co2:
+                    valColName = "co2_val";
+                    break;
+                case SensorType.fan:
+                    valColName = "fan_val";
+                    break;
+              default: 
+                    break;
+              }
           _readingTypeConfig.clear();
           _readingTypeConfig.addAll({
             'val_sensor': {
               'title': '',
               'dataFields': [
                 {
-                  'field': 'val',
+                  'field': valColName,
                 }
               ],
               'timeKey': 'time',

--- a/lib/up_helper/helper/device_def.dart
+++ b/lib/up_helper/helper/device_def.dart
@@ -14,6 +14,7 @@ enum SensorType {
   co2,
   fan,
   switchSensor,
+  temperature_humidity,
   unknown,
 }
 
@@ -135,6 +136,8 @@ SensorType? getSensorType(String sensorTypeTag) {
   switch (sensorTypeTag.toUpperCase()) {
     case 'TEMPERATURE':
       return SensorType.temperature;
+    case 'TEMPERATURE_HUMIDITY':
+      return SensorType.temperature_humidity;
     case 'HUMIDITY':
       return SensorType.humidity;
     case 'IR':

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.18.3
+version: 2.18.4
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces support for a new sensor type, `temperature_humidity`, across the codebase, along with improvements to how item types are handled in query maps. The changes ensure that the new sensor type is properly recognized, mapped, and that its data is correctly processed and displayed.

**Support for new sensor type and data handling:**

* Added `temperature_humidity` to the `SensorType` enum and updated the `getSensorType` function to recognize the `TEMPERATURE_HUMIDITY` tag. [[1]](diffhunk://#diff-e205919aa053e8199b1c49ac13f0aae71b22c2c3ac91caa05400d04649de519fR17) [[2]](diffhunk://#diff-e205919aa053e8199b1c49ac13f0aae71b22c2c3ac91caa05400d04649de519fR139-R140)
* Updated the sensor data presentation logic in `wgt_pag_item_history_presenter.dart` to handle `temperature_humidity` and select the appropriate value column (`temperature_val`) for charting and data display.

**Improvements to query map construction:**

* Modified the construction of the `queryMap` in `wgt_pag_item_history_getter.dart` to ensure the `item_type` is set correctly, using either `itemTypeStr` or a fallback value, and to explicitly set `item_type` after data retrieval. [[1]](diffhunk://#diff-eeb33a584b63bd4c7229610533309501e9a4898a02490020e338dfab420fba7cL287-R287) [[2]](diffhunk://#diff-eeb33a584b63bd4c7229610533309501e9a4898a02490020e338dfab420fba7cR327-R328)

**Version update:**

* Bumped the package version to `2.18.4` in `pubspec.yaml` to reflect these changes.