### PR TITLE
update job request

### DIFF
--- a/lib/pag_helper/wgt/job/wgt_post_job.dart
+++ b/lib/pag_helper/wgt/job/wgt_post_job.dart
@@ -1,4 +1,5 @@
 import 'package:buff_helper/pag_helper/model/acl/mdl_pag_svc_claim.dart';
+import 'package:buff_helper/pagrid_helper/job_helper/job_helper.dart';
 import 'package:buff_helper/pkg_buff_helper.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -41,7 +42,12 @@ class _WgtPagPostJobState extends State<WgtPagPostJob> {
   Future<dynamic> _postJob() async {
     try {
       Map<String, dynamic> jobRequest = widget.jobRequest;
-      jobRequest['job_task_type'] = PagJobTaskType.itemHistory.name;
+      // jobRequest['job_task_type'] = PagJobTaskType.itemHistory.name;
+      jobRequest['job_task_type'] = getPagJobTaskTypeName(PagJobTaskType.itemHistory);
+      // jobRequest['job_type'] = 'item-history';
+      String projectLabel = widget.loggedInUser.selectedScope.projectProfile?.label ?? '';
+      jobRequest['job_type'] = jobRequest['job_task_type'] + (projectLabel.isNotEmpty ? '-$projectLabel' : '');
+
 
       if ((widget.loggedInUser.emailVerified ?? false) &&
           widget.loggedInUser.email != null) {


### PR DESCRIPTION
This pull request updates the way job type information is set in the `_postJob` method of the `_WgtPagPostJobState` class, aiming for improved flexibility and correctness in job requests. The changes also introduce a new import to support these updates.

**Job type assignment improvements:**

* The assignment of `job_task_type` now uses the helper function `getPagJobTaskTypeName` instead of directly accessing the enum's `name`, allowing for better abstraction and potential future changes to naming conventions. (`lib/pag_helper/wgt/job/wgt_post_job.dart`, [lib/pag_helper/wgt/job/wgt_post_job.dartL44-R50](diffhunk://#diff-87c7abcbad856bcdddb21683322b43961fc139db8325daa4cd9f0ef9b16fc180L44-R50))
* The `job_type` field is now dynamically constructed by combining `job_task_type` with the current project's label (if available), making job requests more descriptive and context-aware. (`lib/pag_helper/wgt/job/wgt_post_job.dart`, [lib/pag_helper/wgt/job/wgt_post_job.dartL44-R50](diffhunk://#diff-87c7abcbad856bcdddb21683322b43961fc139db8325daa4cd9f0ef9b16fc180L44-R50))

**Dependency update:**

* Added an import for `job_helper.dart` to enable the use of the `getPagJobTaskTypeName` helper function. (`lib/pag_helper/wgt/job/wgt_post_job.dart`, [lib/pag_helper/wgt/job/wgt_post_job.dartR2](diffhunk://#diff-87c7abcbad856bcdddb21683322b43961fc139db8325daa4cd9f0ef9b16fc180R2))