### PR TITLE
support for add pa devices

### DIFF
--- a/lib/pag_helper/comm/comm_meter.dart
+++ b/lib/pag_helper/comm/comm_meter.dart
@@ -62,3 +62,59 @@ Future<dynamic> doPagCreateMeter(
     throw Exception(jsonDecode(response.body)['error']);
   }
 }
+
+Future<dynamic> doPagCreateDevice(
+  MdlPagUser loggedInUser,
+  MdlPagAppConfig appConfig,
+  Map<String, dynamic> queryMap,
+  MdlPagSvcClaim svcClaim,
+) async {
+  svcClaim.svcName = PagSvcType.oresvc2.name;
+  svcClaim.endpoint = PagUrlBase.eptPagCreateDevice2;
+
+  String svcToken = '';
+  // try {
+  //   svcToken = await svcGate(svcClaim /*, queryByUser*/);
+  // } catch (err) {
+  //   throw Exception(err);
+  // }
+
+  final response = await http.post(
+    Uri.parse(PagUrlController(loggedInUser, appConfig)
+        .getUrl(PagSvcType.oresvc2, svcClaim.endpoint!)),
+    headers: <String, String>{
+      'Content-Type': 'application/json; charset=UTF-8',
+      'Authorization': 'Bearer $svcToken',
+    },
+    body: jsonEncode(MdlPagSvcQuery(svcClaim, queryMap).toJson()),
+  );
+
+  if (response.statusCode == 201) {
+    // If the server did return a 201 CREATED response, parse the JSON.
+    final responseBody = jsonDecode(response.body);
+
+    if (responseBody['info'] != null) {
+      throw Exception(responseBody['info']);
+    }
+    if (responseBody['error'] != null) {
+      throw Exception(responseBody['error']);
+    }
+    final data = responseBody['data'];
+    if (data == null) {
+      throw Exception("No data found in the response");
+    }
+    final result = data['result'];
+    if (result == null) {
+      throw Exception("No result found in the response");
+    }
+    String? resultKey = data['result_key'];
+    if (resultKey == null && resultKey!.isEmpty) {
+      throw Exception("Error: $resultKey");
+    }
+    return result[resultKey];
+  } else if (response.statusCode == 403) {
+    throw Exception("You are not authorized to perform this operation");
+  } else {
+    throw Exception(jsonDecode(response.body)['error']);
+  }
+}

--- a/lib/pag_helper/comm/pag_be_api_base.dart
+++ b/lib/pag_helper/comm/pag_be_api_base.dart
@@ -400,6 +400,7 @@ class PagUrlBase {
 
   // AM - Device Manager
   static const String eptPagCreateDevice = '/am/device/create_device';
+    static const String eptPagCreateDevice2 = '/am/device/create_device2';
 
   // AM - Comms Manager
   static const String eptAmCommsUpdateDeviceLinkage =

--- a/lib/pag_helper/def_helper/dh_device.dart
+++ b/lib/pag_helper/def_helper/dh_device.dart
@@ -152,3 +152,43 @@ String? validateSerialNumber(String val) {
   }
   return null;
 }
+
+
+String? validateDeviceIccid(String val) {
+  val = val.trim();
+
+  if (val.isEmpty) {
+    return 'required';
+  }
+
+  // At least 7 digits
+  String pattern = r'^\d{7,}$';
+  RegExp regExp = RegExp(pattern);
+  if (!regExp.hasMatch(val)) {
+    return 'must have at least 7 digits';
+  }
+
+  return null;
+}
+
+String? validateIp(String val) {
+  val = val.trim();
+  
+  if (val.isEmpty) {
+    return 'required';
+  }
+
+  // IPv4 pattern: 0-255.0-255.0-255.0-255
+  String pattern =
+      r'^((25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)\.){3}'
+      r'(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)$';
+  
+  RegExp regExp = RegExp(pattern);
+  if (!regExp.hasMatch(val)) {
+    return 'invalid IP address';
+  }
+
+  return null;
+}
+
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.21.1
+version: 2.21.2
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces new functionality for device creation and adds validation helpers for device data, along with a minor version bump. The main changes include a new API call for device creation, new validation functions for device ICCID and IP addresses, and an update to the API endpoint constants.

**Device creation enhancements:**
* Added `doPagCreateDevice` function to `comm_meter.dart` to support device creation via the new `/am/device/create_device2` endpoint, including error handling for various response scenarios.
* Added new API endpoint constant `eptPagCreateDevice2` in `pag_be_api_base.dart` to support the updated device creation flow.

**Validation helpers:**
* Added `validateDeviceIccid` function to `dh_device.dart` to ensure ICCID is present and contains at least 7 digits.
* Added `validateIp` function to `dh_device.dart` to validate IPv4 address format.

**Version update:**
* Bumped package version from `2.21.1` to `2.21.2` in `pubspec.yaml`.