### PR TITLE
update item id to display id, and sanitize the display id to replace …

### DIFF
--- a/lib/pag_helper/wgt/history_presentor/wgt_pag_item_history_presenter.dart
+++ b/lib/pag_helper/wgt/history_presentor/wgt_pag_item_history_presenter.dart
@@ -1242,7 +1242,7 @@ class _WgtPagItemHistoryPresenterState
     return WgtPagHistoryRepList(
       loggedInUser: widget.loggedInUser,
       appConfig: widget.appConfig,
-      itemId: widget.itemId,
+      itemId: formatFileName(widget.displayId ?? widget.itemId),
       readingTypeConfig: _readingTypeConfig,
       readingTypes: _selectedMultiFields.map((e) => e.value!).toList(),
       listKey: _intRefreshKey,

--- a/lib/util/util.dart
+++ b/lib/util/util.dart
@@ -149,6 +149,16 @@ String makeReportName(
   return reportName;
 }
 
+String formatFileName(String input) {
+  // Replace all non-alphanumeric characters with '_'
+  String sanitized = input.replaceAll(RegExp(r'[^a-zA-Z0-9]'), '_');
+  // Collapse multiple consecutive '_' into a single '_'
+  sanitized = sanitized.replaceAll(RegExp(r'_+'), '_');
+  // Optionally, trim leading/trailing underscores
+  sanitized = sanitized.replaceAll(RegExp(r'^_|_$'), '');
+  return sanitized;
+}
+
 bool canPullData(bool hasData, DateTime? lastRequst, int? reqInterval,
     DateTime? lastLoad, int? loadInteval) {
   // if (!hasData) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.21.2
+version: 2.21.3
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces a new utility function to sanitize file names and applies it to the history presenter, ensuring consistent and safe file naming throughout the application. The package version is also incremented to reflect these changes.

**File name sanitization improvements:**

* Added a new `formatFileName` function in `lib/util/util.dart` to sanitize input strings by replacing non-alphanumeric characters with underscores, collapsing consecutive underscores, and trimming leading/trailing underscores.
* Updated `itemId` assignment in `_WgtPagItemHistoryPresenterState` (`lib/pag_helper/wgt/history_presentor/wgt_pag_item_history_presenter.dart`) to use the new `formatFileName` function, ensuring file names are properly formatted when passed to `WgtPagHistoryRepList`.

**Version update:**

* Bumped package version from `2.21.2` to `2.21.3` in `pubspec.yaml` to reflect the new utility and usage changes.…any non alphanumeric character to underscore for report naming purpose