### PR TITLE
service type

### DIFF
--- a/lib/pag_helper/def_helper/dh_device.dart
+++ b/lib/pag_helper/def_helper/dh_device.dart
@@ -244,6 +244,19 @@ String? validateTag(String val) {
   return null;
 }
 
+String? validateServiceType(String val) {
+
+  // Service Type pattern: letter, number, underscore, dash, space, 1 to 21 characters
+
+  String pattern = r'^[a-zA-Z0-9_ -]{1,21}$';
+  RegExp regExp = RegExp(pattern);
+  if (!regExp.hasMatch(val)) {
+    return 'invalid IP address';
+  }
+
+  return null;
+}
+
 enum PagDeviceOps {
   onboarding,
   update,
@@ -375,7 +388,7 @@ final List<Map<String, dynamic>> listConfigBaseMeterGroup = [
     'col_type': 'string',
     'width': 150,
     'is_mapping_required': true,
-    'validator': validateIp,
+    'validator': validateServiceType,
   },
   {
     'col_key': 'site_label',


### PR DESCRIPTION
This pull request adds a new validation function for service type strings and updates the configuration for the meter group to use this validator instead of the previous IP address validator. The main focus is on ensuring that the service type field accepts only valid characters and length.

Validation improvements:

* Added the `validateServiceType` function to `dh_device.dart` to validate service type strings, allowing only letters, numbers, underscores, dashes, and spaces, with a length between 1 and 21 characters.

Configuration updates:

* Updated the `listConfigBaseMeterGroup` configuration in `dh_device.dart` to use `validateServiceType` as the validator for the service type field instead of `validateIp`.