### PR TITLE
meter trending usage col and bill pdf name update

### DIFF
--- a/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
+++ b/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
@@ -30,6 +30,7 @@ class WgtHistoryRepList extends StatefulWidget {
     this.showIndex = true,
     this.fullCols = false,
     this.jobRequest = const {},
+    this.valDiffTitle,
   });
 
   final PaGridAppConfig appConfig;
@@ -50,6 +51,7 @@ class WgtHistoryRepList extends StatefulWidget {
   final bool showIndex;
   final bool fullCols;
   final Map<String, String> jobRequest;
+  final String? valDiffTitle;
 
   @override
   _WgtHistoryRepListState createState() => _WgtHistoryRepListState();
@@ -106,6 +108,11 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
         _listConfig.add({
           'fieldKey': keyName,
           'title': fieldKey['display_header'] ?? fieldKey['field'],
+          'width': fieldKey['width'] ?? 150,
+        });
+        _listConfig.add({
+          'fieldKey': '${fieldKey['field']}_diff',
+          'title': widget.valDiffTitle ?? '${fieldKey['field']}_diff',
           'width': fieldKey['width'] ?? 150,
         });
         if (keyName == 'a_imp') {
@@ -221,6 +228,8 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
 
     if (kDebugMode) {
       print('list length: ${_list.length}');
+      print('list config length: ${_listConfig.length}');
+      print('list config: $_listConfig');
     }
 
     return SizedBox(
@@ -371,6 +380,7 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
         ),
       );
     }
+
     return ListTile(
       dense: true,
       // visualDensity: VisualDensity(vertical: -4),

--- a/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
+++ b/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
@@ -228,8 +228,6 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
 
     if (kDebugMode) {
       print('list length: ${_list.length}');
-      print('list config length: ${_listConfig.length}');
-      print('list config: $_listConfig');
     }
 
     return SizedBox(
@@ -380,7 +378,6 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
         ),
       );
     }
-
     return ListTile(
       dense: true,
       // visualDensity: VisualDensity(vertical: -4),

--- a/lib/pagrid_helper/chart_helper/history_presentor/wgt_item_history_presenter.dart
+++ b/lib/pagrid_helper/chart_helper/history_presentor/wgt_item_history_presenter.dart
@@ -1436,6 +1436,7 @@ class _WgtItemHistoryPresenterState extends State<WgtItemHistoryPresenter> {
       endDate: _endDate,
       fullCols: _fullCols,
       jobRequest: _jobRequest,
+      valDiffTitle: 'usage',
     );
   }
 

--- a/lib/pagrid_helper/ems_helper/billing_helper/wgt_bill_render_pdf.dart
+++ b/lib/pagrid_helper/ems_helper/billing_helper/wgt_bill_render_pdf.dart
@@ -44,7 +44,9 @@ class _WgtBillRenderPdfState extends State<WgtBillRenderPdf> {
     LayoutCallback build,
     PdfPageFormat pageFormat,
   ) async {
-    String suffix = '';
+    String suffix = widget.billingInfo.containsKey('billingRecName')
+        ? '-${widget.billingInfo['billingRecName']}'
+        : '';
     //if web
     if (kIsWeb) {
       await generateAndSavePdfWeb(


### PR DESCRIPTION
This pull request introduces enhancements to the history presenter widget and improves the handling of PDF file naming in the billing helper. The main changes include adding support for a custom diff column title in the history report list and making the PDF file suffix more descriptive based on billing information.

**Enhancements to history presenter:**
- Added a new optional `valDiffTitle` parameter to the `WgtHistoryRepList` widget, allowing customization of the diff column title. [[1]](diffhunk://#diff-dea78a3628be24fce51d763230efc30174fa79fb26bd6d12d87d1ba977fae0feR33) [[2]](diffhunk://#diff-dea78a3628be24fce51d763230efc30174fa79fb26bd6d12d87d1ba977fae0feR54)
- Updated the `_listConfig` in `_WgtHistoryRepListState` to add a diff column for each field, using the provided `valDiffTitle` or a default value.
- Set the `valDiffTitle` to `'usage'` in the `WgtItemHistoryPresenter` to demonstrate usage of the new feature.

**Improvements to billing PDF generation:**
- Modified the PDF file suffix in `WgtBillRenderPdf` to include the `billingRecName` from `billingInfo` when available, making the file name more informative.