### PR TITLE
add utown validator

### DIFF
--- a/lib/pagrid_helper/project_helper/project_setting.dart
+++ b/lib/pagrid_helper/project_helper/project_setting.dart
@@ -461,7 +461,8 @@ String? nusSnValidator(String displayname) {
     bool isRvrc = isRVRC(displayname) == null;
     bool isVh = isVH(displayname) == null;
     bool isNusC = isNUSC(displayname) == null;
-    if(isVh || isRvrc || isNusC) {
+    bool isUtrNorth = isUTRNorth(displayname) == null;
+    if(isVh || isRvrc || isNusC || isUtrNorth) {
       return null;
     }
     return 'Invalid displayname';
@@ -525,6 +526,14 @@ String? isVH(String displayname) {
 String? isNUSC(String displayname) {
   int displaynameInt = int.parse(displayname);
   if (displaynameInt < 10002801  || (displaynameInt > 10003925 && displaynameInt != 10003963 && displaynameInt != 10003982 && displaynameInt != 10003985 && displaynameInt != 10009999)) {
+    return 'Invalid displayname';
+  }
+  return null;
+}
+
+ String? isUTRNorth(String displayname) {
+  int displaynameInt = int.parse(displayname);
+  if ((displaynameInt < 10100700 && !{10000713, 10000744,10000780,10000781,10000782,10000783,10000784}.contains(displaynameInt)) || (displaynameInt > 10101296)) {
     return 'Invalid displayname';
   }
   return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.21.6
+version: 2.22.0
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request updates the validation logic in `project_setting.dart` to add support for UTR North display names and bumps the package version to reflect this new functionality.

Validation logic enhancements:
* Added a new function `isUTRNorth` to validate UTR North display names based on specific numeric ranges and exceptions.
* Updated the `nusSnValidator` function to accept UTR North display names as valid by incorporating the new `isUTRNorth` check.

Version update:
* Increased the package version from `2.21.6` to `2.22.0` in `pubspec.yaml` to indicate the addition of new validation logic.