### PR TITLE
add utr south validator

### DIFF
--- a/lib/pagrid_helper/project_helper/project_setting.dart
+++ b/lib/pagrid_helper/project_helper/project_setting.dart
@@ -462,7 +462,8 @@ String? nusSnValidator(String displayname) {
     bool isVh = isVH(displayname) == null;
     bool isNusC = isNUSC(displayname) == null;
     bool isUtrNorth = isUTRNorth(displayname) == null;
-    if(isVh || isRvrc || isNusC || isUtrNorth) {
+    bool isUtrSouth = isUTRSouth(displayname) == null;
+    if(isVh || isRvrc || isNusC || isUtrNorth || isUtrSouth) {
       return null;
     }
     return 'Invalid displayname';
@@ -534,6 +535,14 @@ String? isNUSC(String displayname) {
  String? isUTRNorth(String displayname) {
   int displaynameInt = int.parse(displayname);
   if ((displaynameInt < 10100700 && !{10000713, 10000744,10000780,10000781,10000782,10000783,10000784}.contains(displaynameInt)) || (displaynameInt > 10101296)) {
+    return 'Invalid displayname';
+  }
+  return null;
+}
+
+ String? isUTRSouth(String displayname) {
+  int displaynameInt = int.parse(displayname);
+  if ((displaynameInt < 10000000  || (displaynameInt > 10003984 && !{10101297, 10101298,10101299,10101300,10101301,10101302}.contains(displaynameInt)))) {
     return 'Invalid displayname';
   }
   return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.22.0
+version: 2.23.0
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request adds validation logic for a new category of display names, specifically handling "UTR South" cases, and increments the package version to reflect this update. The main changes involve extending the validation logic and updating the package metadata.

**Validation logic updates:**

* Added a new function `isUTRSouth` in `project_setting.dart` to validate display names for the "UTR South" category. This function checks if the display name falls within a specific range or matches a set of allowed values.
* Updated the `nusSnValidator` function to include the new `isUTRSouth` check, allowing "UTR South" display names to be considered valid.

**Package metadata:**

* Bumped the version in `pubspec.yaml` from `2.22.0` to `2.23.0` to reflect the new validation logic.