### PR TITLE
userInfo to user_info

### DIFF
--- a/lib/pag_helper/model/mdl_pag_user.dart
+++ b/lib/pag_helper/model/mdl_pag_user.dart
@@ -478,7 +478,7 @@ class MdlPagUser {
 
   factory MdlPagUser.fromJson2(Map<String, dynamic> respJson) {
     try {
-      Map<String, dynamic> userJson = respJson['userInfo'];
+      Map<String, dynamic> userJson = respJson['user_info'];
       assert(
           userJson['error'] == null, 'Error in response: ${userJson['error']}');
       List<MdlPagRole> roleList = [];


### PR DESCRIPTION
This pull request updates the JSON parsing logic in the `MdlPagUser` model to match the expected API response format.

- **Bug Fixes / API Compatibility:**
  * Changed the key used to extract user information from the JSON response in the `fromJson2` factory constructor of `MdlPagUser` from `'userInfo'` to `'user_info'`, ensuring compatibility with the API's current response format.