### PR TITLE
update oresvc path

### DIFF
--- a/lib/pagrid_helper/comm_helper/be_api_base.dart
+++ b/lib/pagrid_helper/comm_helper/be_api_base.dart
@@ -124,7 +124,7 @@ class UrlBase {
   static const String _rDestPortalEvs2cp = 'https://cp2.evs.com.sg';
 
   static const String _dOresvcUrl = 'http://localhost:8018';
-  static const String _rOresvc = 'https://ore.evs.com.sg';
+  static const String _rOresvc = 'https://ore-op2.evs.com.sg';
   static const String _rDevOresvcNTU = _rOresvc;
   static const String _rProdOresvcUrlNTU = 'https://ore-ntu.evs.com.sg';
   static const String _rDevOresvcUrlSMRT = _rOresvc;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.23.1
+version: 2.23.2
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request includes a minor update to the project, primarily involving a change to the production ORESVC URL and a version bump.

* Project configuration:
  * Updated the project version in `pubspec.yaml` from `2.23.1` to `2.23.2`.

* Backend API URL update:
  * Changed the production ORESVC URL in `be_api_base.dart` from `https://ore.evs.com.sg` to `https://ore-op2.evs.com.sg`.