### PR TITLE
motherboard sn validator update

### DIFF
--- a/lib/pag_helper/def_helper/dh_device.dart
+++ b/lib/pag_helper/def_helper/dh_device.dart
@@ -175,7 +175,8 @@ String? validateSerialNumber(String val) {
   }
   // validate number, letter, underscore, and dash,
   // and minimum 5 characters
-  String pattern = r'^[a-zA-Z0-9_ -]{5,}$';
+  // String pattern = r'^[a-zA-Z0-9_ -]{5,}$';
+  String pattern = r'^[a-zA-Z0-9_<>\-/ ]{5,}$';
   RegExp regExp = RegExp(pattern);
   if (!regExp.hasMatch(val)) {
     return 'min length is 5 and letter, number, _, - only';

--- a/lib/xt_ui/xt_globals.dart
+++ b/lib/xt_ui/xt_globals.dart
@@ -1,6 +1,7 @@
 // This file contains all the global variables and constants used in the app
 const int maxLoginNameLength = 30;
 const int maxFullNameLength = 50;
+const int maxRawFullNameLength = 100;
 const int maxEmailLength = 250;
 const int maxPhoneLength = 20;
 const int maxPasswordLength = 30;


### PR DESCRIPTION
This pull request introduces a minor update to the serial number validation logic and adds a new global constant for raw full name length. The changes are straightforward and focus on improving input validation and configuration.

Validation logic update:

* Expanded the allowed characters in the serial number validation regex in `validateSerialNumber` within `dh_device.dart` to include `<`, `>`, `/`, and space, in addition to the previously allowed characters.

Global constants:

* Added a new constant `maxRawFullNameLength` (set to 100) to `xt_globals.dart` for managing the maximum length of raw full names.