### PR TITLE
usage/diff for kwh only 

### DIFF
--- a/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
+++ b/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
@@ -110,11 +110,14 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
           'title': fieldKey['display_header'] ?? fieldKey['field'],
           'width': fieldKey['width'] ?? 150,
         });
-        _listConfig.add({
-          'fieldKey': '${fieldKey['field']}_diff',
-          'title': widget.valDiffTitle ?? '${fieldKey['field']}_diff',
-          'width': fieldKey['width'] ?? 150,
-        });
+        // only get usage / diff for val and skip usage for flow, power, volume, forward_temp and return_temp by cw nus requirement - yj
+        if (keyName == 'val') {
+          _listConfig.add({
+            'fieldKey': '${fieldKey['field']}_diff',
+            'title': widget.valDiffTitle ?? '${fieldKey['field']}_diff',
+            'width': fieldKey['width'] ?? 150,
+          });
+        }
         if (keyName == 'a_imp') {
           _listConfig.add({
             'fieldKey': 'a_imp_diff',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.23.2
+version: 2.23.3
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces a targeted update to the `WgtHistoryRepList` widget and bumps the package version. The main change refines which fields receive a "diff" (difference/usage) column in historical report lists, aligning with specific requirements.

Key changes:

**Feature refinement:**

* Updated logic in `wgt_history_rep_list.dart` to only add a "diff" column for the `val` field, skipping it for `flow`, `power`, `volume`, `forward_temp`, and `return_temp`, as per CW NUS requirements.

**Versioning:**

* Incremented the package version to `2.23.3` in `pubspec.yaml` to reflect the update.