### PR TITLE
update model validator to allow GH1

### DIFF
--- a/lib/pag_helper/def_helper/dh_device.dart
+++ b/lib/pag_helper/def_helper/dh_device.dart
@@ -193,7 +193,8 @@ String? validateModel(String val) {
   }
 
   // Pattern: int.int.int[.alphanumeric] or int.int.int[.int]
-  final pattern = r'^\d{1,3}\.\d{1,3}\.\d{1,3}(\.[A-Za-z0-9]+)?$';
+  // final pattern = r'^\d{1,3}\.\d{1,3}\.\d{1,3}(\.[A-Za-z0-9]+)?$';
+  final pattern = r'^(\d{1,3}\.\d{1,3}\.\d{1,3}(\.[A-Za-z0-9]+)?|[A-Za-z0-9]+)$';
 
   final regExp = RegExp(pattern);
 

--- a/lib/pag_helper/def_helper/dh_device.dart
+++ b/lib/pag_helper/def_helper/dh_device.dart
@@ -194,7 +194,7 @@ String? validateModel(String val) {
 
   // Pattern: int.int.int[.alphanumeric] or int.int.int[.int]
   // final pattern = r'^\d{1,3}\.\d{1,3}\.\d{1,3}(\.[A-Za-z0-9]+)?$';
-  final pattern = r'^(\d{1,3}\.\d{1,3}\.\d{1,3}(\.[A-Za-z0-9]+)?|[A-Za-z0-9]+)$';
+  final pattern = r'^(\d{1,3}\.\d{1,3}\.\d{1,3}(\.[A-Za-z0-9]+)?|[A-Za-z0-9]{3})$';
 
   final regExp = RegExp(pattern);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.23.4
+version: 2.23.5
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces a small update to the package version and expands the device model validation logic to support additional formats.

Device model validation improvements:

* Updated the regex pattern in `validateModel` (`dh_device.dart`) to allow either the original `int.int.int[.alphanumeric]` format or a 3-character alphanumeric string, increasing flexibility for device model identifiers.

Project versioning:

* Incremented the package version in `pubspec.yaml` from `2.23.4` to `2.23.5` to reflect the new changes.