### PR TITLE
mcu health panel update

### DIFF
--- a/lib/pag_helper/wgt/app/fh/wgt_fh_device_health.dart
+++ b/lib/pag_helper/wgt/app/fh/wgt_fh_device_health.dart
@@ -324,9 +324,11 @@ class _WgtFhDeviceHealthState extends State<WgtFhDeviceHealth> {
   Widget getTopStatPnl() {
     String submittedTimestamp = _deviceHealthData['submitted_timestamp'] ?? '';
     final content = _deviceHealthData['content'];
-    final version = content['v'];
-    final temperature = content['t'];
-    final signal = content['s'];
+    final version = content['v'] ?? '-';
+    final temperature = content['t'] == null ?
+        '-' :
+        '${content['t']}°C';
+    final signal = content['s'] ?? '-';
     final signalPercentage = content['s'] == null
         ? '-'
         : '${(int.parse(content['s'] as String) * 100 / 31).clamp(0, 100).toInt()}%';
@@ -387,7 +389,7 @@ class _WgtFhDeviceHealthState extends State<WgtFhDeviceHealth> {
                         color: Theme.of(context).hintColor),
                     SizedBox(
                         width: valueWidth,
-                        child: Text('$temperature°C', style: valueStyle)),
+                        child: Text(temperature, style: valueStyle)),
                   ],
                 ),
               ),
@@ -433,12 +435,15 @@ class _WgtFhDeviceHealthState extends State<WgtFhDeviceHealth> {
 
   Widget getMeterGroupStatus() {
     final meterGroupLabel =
-        _deviceHealthData['meter_group_label'] ?? 'Unknown';
+        _deviceHealthData['meter_group_label'];
 
     final content = _deviceHealthData['content'];
     final errorList = content['el'];
     final meterInfoList = _deviceHealthData['meter_info_list'] ?? [];
-    final String lastOnlineTimestamp = _deviceHealthData['gateway_last_online_timestamp'] ?? '';
+    final String lastOnlineTimestamp = _deviceHealthData['${widget.deviceCat.name}_last_online_timestamp'] ?? '';
+
+    bool isMeterGroupExist = meterGroupLabel != null && meterGroupLabel.isNotEmpty;
+    String labelToShow = isMeterGroupExist ? meterGroupLabel + ' ($lastOnlineTimestamp)' : lastOnlineTimestamp;
 
     // sort by tag strings
     meterInfoList.sort((a, b) {
@@ -485,14 +490,16 @@ class _WgtFhDeviceHealthState extends State<WgtFhDeviceHealth> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                SizedBox(
-                    width: keyWidth,
-                    child: Icon(PagDeviceCat.meterGroup.iconData,
-                        color: Theme.of(context).hintColor)),
+                isMeterGroupExist
+                        ? SizedBox(
+                            width: keyWidth,
+                            child:  Icon(PagDeviceCat.meterGroup.iconData,
+                                    color: Theme.of(context).hintColor))
+                        : const SizedBox.shrink(),
                 horizontalSpaceTiny,
                 SizedBox(
                     width: valueWidth,
-                    child: Text(meterGroupLabel + ' ($lastOnlineTimestamp)', style: valueStyle)),
+                    child: Text(labelToShow, style: valueStyle)),
               ],
             ),
           ),


### PR DESCRIPTION
This pull request introduces improvements to the display logic for device health information in the `WgtFhDeviceHealth` widget. The changes focus on handling null values more gracefully and dynamically constructing labels based on available data, which enhances the robustness and clarity of the UI.

**Device health data display improvements:**

* Temperature, version, and signal values are now displayed as `'-'` when missing, and the temperature value is formatted with a degree symbol only when present. [[1]](diffhunk://#diff-18cc4348a3e957852f9fc37b21427cb98e47474c3f9dc03c4f248509e3ffad45L327-R331) [[2]](diffhunk://#diff-18cc4348a3e957852f9fc37b21427cb98e47474c3f9dc03c4f248509e3ffad45L390-R392)
* Signal percentage calculation is safeguarded against null values, ensuring a fallback value of `'-'` if the signal is missing.

**Meter group status display enhancements:**

* The meter group label is now shown only if it exists and is non-empty; otherwise, only the last online timestamp is displayed. The label is constructed dynamically to include the timestamp. [[1]](diffhunk://#diff-18cc4348a3e957852f9fc37b21427cb98e47474c3f9dc03c4f248509e3ffad45L436-R446) [[2]](diffhunk://#diff-18cc4348a3e957852f9fc37b21427cb98e47474c3f9dc03c4f248509e3ffad45L488-R502)
* The icon for the meter group is conditionally rendered based on the existence of the meter group label, preventing unnecessary UI elements when the label is absent.