### PR TITLE
add adapter validator 

### DIFF
--- a/lib/pag_helper/def_helper/dh_device.dart
+++ b/lib/pag_helper/def_helper/dh_device.dart
@@ -274,6 +274,20 @@ String? validateDeviceType(String val) {
   return null;
 }
 
+String? validateAdapterType(String? val) {
+  if (val == null || val.trim().isEmpty) {
+    return 'required';
+  }
+
+  String value = val.toLowerCase();
+
+  if (!value.contains('jbs2') && !value.contains('evs2sim')) {
+    return 'Value must contain "jbs2" or "evs2sim"';
+  }
+
+  return null;
+}
+
 String? validateTag(String val) {
   val = val.trim();
 
@@ -532,6 +546,14 @@ final List<Map<String, dynamic>> listConfigBaseSim = [
     'width': 200,
     'is_mapping_required': true,
     'validator': validateDeviceType,
+  },
+  {
+    'col_key': 'adapter_type',
+    'title': 'Adapter Type',
+    'col_type': 'string',
+    'width': 200,
+    'is_mapping_required': true,
+    'validator': validateAdapterType,
   },
 ];
 

--- a/lib/pag_helper/def_helper/pag_item_helper.dart
+++ b/lib/pag_helper/def_helper/pag_item_helper.dart
@@ -67,6 +67,20 @@ enum PagDeviceLsStatus {
       normal;
 }
 
+enum PagSimPackageEnum {
+  nano("Nano"),
+  micro("Micro"),
+  standard("Standard"),
+  ;
+
+  const PagSimPackageEnum(this.label);
+
+  final String label;
+
+  static PagSimPackageEnum? byLabel(String? label) =>
+      enumByLabel(label, values, (e) => e.label);
+}
+
 // T? enumByLabel<T extends Enum>(
 //   String? label,
 //   List<T> values,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.23.7
+version: 2.23.6
 homepage:
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.23.5
+version: 2.23.7
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces enhancements to device configuration validation and adds a new enum for SIM package types. The changes primarily focus on improving input validation and expanding the supported configuration options for devices.

Validation and configuration enhancements:

* Added a new `validateAdapterType` function to enforce that adapter type values must contain either "jbs2" or "evs2sim", improving input validation for device adapters.
* Extended the `listConfigBaseSim` configuration list to include a new `adapter_type` field with its own validator, allowing adapter type configuration to be validated and managed consistently.

SIM package enum addition:

* Introduced the `PagSimPackageEnum` enum with labels for "Nano", "Micro", and "Standard" SIM package types, along with a static method for lookup by label, making SIM package handling more robust and type-safe.

Version update:

* Updated the package version in `pubspec.yaml` from `2.23.5` to `2.23.6` to reflect the new changes.