### PR TITLE
add block

### DIFF
--- a/lib/up_helper/model/mdl_meter_info.dart
+++ b/lib/up_helper/model/mdl_meter_info.dart
@@ -27,6 +27,7 @@ class MeterInfoModel {
   String? meterDisplayname;
   String? siteTag;
   String? address;
+  String? block;
   String? status;
   String? rlsStatus;
   String? kwhTimestamp;
@@ -42,6 +43,7 @@ class MeterInfoModel {
       this.meterDisplayname,
       this.siteTag,
       this.address,
+      this.block,
       this.status,
       this.rlsStatus,
       this.kwhTimestamp,
@@ -58,6 +60,7 @@ class MeterInfoModel {
       meterDisplayname: json['meter_displayname'],
       siteTag: json['site_tag'] ?? '',
       address: json['address'],
+      block: json['block'] ?? '',
       status: json['status'] ?? '',
       rlsStatus: json['rls_status'] ?? '',
       kwhTimestamp: json['kwh_timestamp'] ?? '',
@@ -80,6 +83,7 @@ class MeterInfoModel {
       'meter_displayname': meterDisplayname,
       'site_tag': siteTag,
       'address': address,
+      'block': block,
       'status': status,
       'comm_type': commType,
       'rls_status': rlsStatus,


### PR DESCRIPTION
This pull request adds a new `block` field to the `MeterInfoModel` class, ensuring that the model can now store and serialize/deserialize block information associated with a meter.

**MeterInfoModel enhancements:**

* Added a new `String? block` property to the `MeterInfoModel` class, updated the constructor to accept it, and included it in both `fromJson` and `toJson` methods for proper serialization and deserialization. [[1]](diffhunk://#diff-b60507ddbe3b61b705acab4353cb70b8768bb06ffcc7c174587bf938e8b64693R30) [[2]](diffhunk://#diff-b60507ddbe3b61b705acab4353cb70b8768bb06ffcc7c174587bf938e8b64693R46) [[3]](diffhunk://#diff-b60507ddbe3b61b705acab4353cb70b8768bb06ffcc7c174587bf938e8b64693R63) [[4]](diffhunk://#diff-b60507ddbe3b61b705acab4353cb70b8768bb06ffcc7c174587bf938e8b64693R86)