### PR TITLE
update meter usage  and meter trend usage to 3dp

### DIFF
--- a/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
+++ b/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
@@ -63,7 +63,7 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
 
   List<Map<String, dynamic>> _listConfig = [];
   final List<Map<String, dynamic>> _list = [];
-  int _decimals = 2;
+  int _decimals = 3;
   String _unit = '';
   bool _jobPosted = false;
 
@@ -438,10 +438,10 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
       String originalFullText = '';
       if (row[configItem['fieldKey']] != null) {
         String str = row[configItem['fieldKey']].toString();
-        // double? value = double.tryParse(str);
-        // originalFullText =
-        //     value == null ? str : value.toStringAsFixed(_decimals);
-          originalFullText = str;
+        double? value = double.tryParse(str);
+        _decimals = 3;
+        originalFullText =
+            value == null ? str : value.toStringAsFixed(_decimals);
         bool dtIsMissing = row['dt_missing'] ?? false;
         if (dtIsMissing && originalFullText is! double) {
           listItemStyle = listItemStyle.copyWith(

--- a/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
+++ b/lib/pagrid_helper/chart_helper/history_presentor/wgt_history_rep_list.dart
@@ -166,7 +166,8 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
       bool hasInsertZero = false;
       for (String key in readings.keys) {
         //get total
-        newRow[key] = readings[key]['rt'];
+        String strRt = getCommaNumberStr(readings[key]['rt'], decimal: 3);
+        newRow[key] = strRt;
         if (widget.fullCols) {
           int isTotalEst = readings[key]['rt_is_est'] ?? 0;
           bool readingPartTotalIsEst = (isTotalEst == 0) ? false : true;
@@ -178,7 +179,8 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
           newRow['${key}_is_neg'] = readingPartTotalIsNeg;
         }
         //get diff
-        newRow['${key}_diff'] = readings[key]['rd'];
+        String strRd = getCommaNumberStr(readings[key]['rd'], decimal: 3);
+        newRow['${key}_diff'] = strRd;
         if (widget.fullCols) {
           int isDiffEst = readings[key]['rd_is_est'] ?? 0;
           bool readingPartDiffIsEst = (isDiffEst == 0) ? false : true;
@@ -436,11 +438,12 @@ class _WgtHistoryRepListState extends State<WgtHistoryRepList> {
       String originalFullText = '';
       if (row[configItem['fieldKey']] != null) {
         String str = row[configItem['fieldKey']].toString();
-        double? value = double.tryParse(str);
-        originalFullText =
-            value == null ? str : value.toStringAsFixed(_decimals);
+        // double? value = double.tryParse(str);
+        // originalFullText =
+        //     value == null ? str : value.toStringAsFixed(_decimals);
+          originalFullText = str;
         bool dtIsMissing = row['dt_missing'] ?? false;
-        if (dtIsMissing && value is! double) {
+        if (dtIsMissing && originalFullText is! double) {
           listItemStyle = listItemStyle.copyWith(
             color: Colors.yellow.shade900,
           );

--- a/lib/xt_ui/wdgt/list/wgt_edit_commit_list.dart
+++ b/lib/xt_ui/wdgt/list/wgt_edit_commit_list.dart
@@ -115,6 +115,7 @@ class _WgtEditCommitListState extends State<WgtEditCommitList> {
   late double _listHeight;
   UniqueKey? _listKey;
   late TextStyle _listItemStyle;
+  final int _decimal = 3;
 
   UniqueKey? _headerRefreshKey;
 
@@ -600,9 +601,8 @@ class _WgtEditCommitListState extends State<WgtEditCommitList> {
             configItem['getDisplayString'](row[configItem['fieldKey']]) ?? '';
       }
       if (configItem['useThousandSeparator'] == true) {
-        int decimal = 3;
         originalFullText =
-            getCommaNumberStr(double.tryParse(originalFullText), decimal: decimal);
+            getCommaNumberStr(double.tryParse(originalFullText), decimal: _decimal);
       }
 
       bool showTag = false;

--- a/lib/xt_ui/wdgt/list/wgt_edit_commit_list.dart
+++ b/lib/xt_ui/wdgt/list/wgt_edit_commit_list.dart
@@ -600,8 +600,9 @@ class _WgtEditCommitListState extends State<WgtEditCommitList> {
             configItem['getDisplayString'](row[configItem['fieldKey']]) ?? '';
       }
       if (configItem['useThousandSeparator'] == true) {
+        int decimal = 3;
         originalFullText =
-            getCommaNumberStr(double.tryParse(originalFullText), decimal: 2);
+            getCommaNumberStr(double.tryParse(originalFullText), decimal: decimal);
       }
 
       bool showTag = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.23.8
+version: 2.23.9
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request standardizes the decimal precision for numerical values displayed in historical and commit lists, increasing it from two to three decimal places across relevant widgets. This ensures consistency and improved accuracy in the presentation of numerical data. Additionally, the package version is incremented to reflect these changes.

**Decimal Precision Standardization:**

* Increased the default decimal precision from 2 to 3 in `_WgtHistoryRepListState`, affecting how values are formatted and displayed throughout the widget (`wgt_history_rep_list.dart`). [[1]](diffhunk://#diff-dea78a3628be24fce51d763230efc30174fa79fb26bd6d12d87d1ba977fae0feL66-R66) [[2]](diffhunk://#diff-dea78a3628be24fce51d763230efc30174fa79fb26bd6d12d87d1ba977fae0feR442-R446)
* Updated the formatting of total (`rt`) and difference (`rd`) values to use three decimal places in the historical report list (`wgt_history_rep_list.dart`). [[1]](diffhunk://#diff-dea78a3628be24fce51d763230efc30174fa79fb26bd6d12d87d1ba977fae0feL169-R170) [[2]](diffhunk://#diff-dea78a3628be24fce51d763230efc30174fa79fb26bd6d12d87d1ba977fae0feL181-R183)
* Set a dedicated `_decimal` field to 3 in `_WgtEditCommitListState` and applied it to number formatting, ensuring three decimal places are shown in commit lists (`wgt_edit_commit_list.dart`). [[1]](diffhunk://#diff-31509a4d191fc1cfd9c90028c3cd638f727709bcb52450f3ea780dda66664fa2R118) [[2]](diffhunk://#diff-31509a4d191fc1cfd9c90028c3cd638f727709bcb52450f3ea780dda66664fa2L604-R605)

**Versioning:**

* Bumped the package version from `2.23.8` to `2.23.9` in `pubspec.yaml` to reflect these updates.