### PR TITLE
validateDeviceLabel update

### DIFF
--- a/lib/pag_helper/def_helper/dh_device.dart
+++ b/lib/pag_helper/def_helper/dh_device.dart
@@ -144,10 +144,12 @@ String? validateDeviceLabel(String val) {
 
   // validate number, letter, underscore, and dash, space,
   // and minimum 5 characters
-  String pattern = r'^[a-zA-Z0-9_ -]{5,}$';
+  // String pattern = r'^[a-zA-Z0-9_ -]{5,}$';
+  String pattern = r'^[a-zA-Z0-9_ \-#().&/]{5,}$';
   RegExp regExp = RegExp(pattern);
   if (!regExp.hasMatch(val)) {
-    return 'min length is 5 and letter, number, space, _, - only';
+    // return 'min length is 5 and letter, number, space, _, - only';
+    return 'min length is 5 and letter, number, space, _, -, #, (, ), ., &, / only';
   }
   return null;
 }


### PR DESCRIPTION
This pull request updates the device label validation logic in `dh_device.dart` to allow a wider range of special characters and improves the corresponding validation message.

**Validation logic update:**

* Expanded the allowed characters in device labels to include `#`, `(`, `)`, `.`, `&`, and `/` in addition to letters, numbers, spaces, underscores, and dashes.
* Updated the validation error message to reflect the newly allowed characters.