### PR TITLE
add email2 and email3 for tenant onboarding ops

### DIFF
--- a/lib/pag_helper/def_helper/dh_pag_tenant.dart
+++ b/lib/pag_helper/def_helper/dh_pag_tenant.dart
@@ -843,6 +843,20 @@ final List<Map<String, dynamic>> listConfigBaseTenantExt = [
     'validator': validateEmail,
   },
   {
+    'col_key': 'billing_email_2',
+    'title': 'Billing Email 2',
+    'col_type': 'email',
+    'width': 150,
+    'is_mapping_required': false
+  },
+  {
+    'col_key': 'billing_email_3',
+    'title': 'Billing Email 3',
+    'col_type': 'email',
+    'width': 150,
+    'is_mapping_required': false
+  },
+  {
     'col_key': 'billing_did',
     'title': 'Billing DID',
     'col_type': 'string',

--- a/lib/pag_helper/def_helper/dh_pag_tenant.dart
+++ b/lib/pag_helper/def_helper/dh_pag_tenant.dart
@@ -847,14 +847,16 @@ final List<Map<String, dynamic>> listConfigBaseTenantExt = [
     'title': 'Billing Email 2',
     'col_type': 'email',
     'width': 150,
-    'is_mapping_required': false
+    'is_mapping_required': false,
+    'validator': validateEmail,
   },
   {
     'col_key': 'billing_email_3',
     'title': 'Billing Email 3',
     'col_type': 'email',
     'width': 150,
-    'is_mapping_required': false
+    'is_mapping_required': false,
+    'validator': validateEmail,
   },
   {
     'col_key': 'billing_did',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.24.2
+version: 2.24.3
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces two new optional billing email fields to the tenant configuration and bumps the package version to reflect this update.

**Tenant configuration enhancements:**
* Added `billing_email_2` and `billing_email_3` as new optional email fields to the `listConfigBaseTenantExt` configuration in `dh_pag_tenant.dart`, each with validation and display settings.

**Version update:**
* Updated the package version in `pubspec.yaml` from `2.24.2` to `2.24.3` to reflect the new changes.