### PR TITLE
add model validator and phase type enum 

### DIFF
--- a/lib/pag_helper/def_helper/dh_device.dart
+++ b/lib/pag_helper/def_helper/dh_device.dart
@@ -228,6 +228,25 @@ String? validateModel(String val) {
   return null;
 }
 
+String? validateCwP2Model(String val) {
+  val = val.trim();
+
+  if (val.isEmpty) {
+    return null;
+  }
+
+  // Alphanumeric, space, dot, underscore, hyphen
+  const pattern = r'^[A-Za-z0-9._ -]+$';
+
+  final regExp = RegExp(pattern);
+
+  if (val.length > 55 || !regExp.hasMatch(val)) {
+    return 'invalid model format, length must be less than 55 and only alphanumeric, space, dot, underscore, hyphen allowed';
+  }
+
+  return null;
+}
+
 String? validatePhaseType(String val) {
   val = val.trim();
 
@@ -768,6 +787,31 @@ enum PagDeviceLsStatus {
         (e) => (e).tag,
       ) ??
       normal;
+}
+
+enum PagMeterPhaseType {
+  single('Single Phase', 'single_phase'),
+  threePhaseDirect('Three Phase Direct', 'three_phase_direct'),
+  threePhaseCt('Three Phase CT', 'three_phase_ct');
+
+  const PagMeterPhaseType(this.key, this.value);
+
+  final String key;    // UI display
+  final String value;  // API / storage
+
+  static PagMeterPhaseType? byKey(String? key) {
+    for (final e in values) {
+      if (e.key == key) return e;
+    }
+    return null;
+  }
+
+  static PagMeterPhaseType? byValue(String? value) {
+    for (final e in values) {
+      if (e.value == value) return e;
+    }
+    return null;
+  }
 }
 
 enum PagSimPackageEnum {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.24.3
+version: 2.24.4
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces a new enum for meter phase types and adds a dedicated model validation function, both in `dh_device.dart`. It also bumps the package version to reflect these additions.

**Enhancements to device helpers:**

* Added a new `PagMeterPhaseType` enum to represent meter phase types, including utility methods for lookup by key or value. (`lib/pag_helper/def_helper/dh_device.dart`)
* Introduced `validateCwP2Model`, a function to validate model strings with specific format and length requirements. (`lib/pag_helper/def_helper/dh_device.dart`)

**Project versioning:**

* Updated package version from `2.24.3` to `2.24.4` in `pubspec.yaml` to reflect the new features.