### PR TITLE
add optional email validator, which allows nullable/empty email 

### DIFF
--- a/lib/pag_helper/def_helper/dh_pag_tenant.dart
+++ b/lib/pag_helper/def_helper/dh_pag_tenant.dart
@@ -848,7 +848,7 @@ final List<Map<String, dynamic>> listConfigBaseTenantExt = [
     'col_type': 'email',
     'width': 150,
     'is_mapping_required': false,
-    'validator': validateEmail,
+    'validator': validateOptionalEmail,
   },
   {
     'col_key': 'billing_email_3',
@@ -856,7 +856,7 @@ final List<Map<String, dynamic>> listConfigBaseTenantExt = [
     'col_type': 'email',
     'width': 150,
     'is_mapping_required': false,
-    'validator': validateEmail,
+    'validator': validateOptionalEmail,
   },
   {
     'col_key': 'billing_did',

--- a/lib/xt_ui/util/xt_util_InputFieldValidator.dart
+++ b/lib/xt_ui/util/xt_util_InputFieldValidator.dart
@@ -133,6 +133,20 @@ String? validateEmail(String? value, {String? emptyCallout}) {
   return result;
 }
 
+String? validateOptionalEmail(String? value) {
+  if (value == null || value.trim().isEmpty) {
+    return null; 
+  }
+
+  final regex = RegExp(glb_reg_email);
+
+  if (!regex.hasMatch(value)) {
+    return glb_email_callout;
+  }
+
+  return null;
+}
+
 String? validatePhone(String? value,
     {String? emptyCallout, Map<Enum, String?>? formErrors, Enum? filedKey}) {
   final phoneRegExp = RegExp(glb_reg_phone);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.24.4
+version: 2.24.5
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces a new optional email validator and updates the configuration to use it for certain billing email fields. This change allows those fields to be left empty without triggering a validation error, while still ensuring that any non-empty value is a valid email address.

**Validation Improvements:**

* Added a new `validateOptionalEmail` function in `xt_util_InputFieldValidator.dart` that returns `null` for empty values and validates the format only if the field is not empty.
* Updated the `listConfigBaseTenantExt` configuration in `dh_pag_tenant.dart` to use `validateOptionalEmail` instead of `validateEmail` for `billing_email_2` and `billing_email_3`, making these fields optional.

**Project Metadata:**

* Incremented the package version in `pubspec.yaml` from `2.24.4` to `2.24.5`.