### PR TITLE
add remark field for tenant onb ops 

### DIFF
--- a/lib/pag_helper/def_helper/dh_pag_tenant.dart
+++ b/lib/pag_helper/def_helper/dh_pag_tenant.dart
@@ -223,6 +223,22 @@ String? validateTenantLabel(String value) {
   return null;
 }
 
+String? validateRemark(String value) {
+  if (value.trim().isEmpty) {
+    return null; // allow empty
+  }
+
+  // length 1-255, alphanumeric, space, /, ', +, -, #, @, (), .
+  String pattern = r"^[-a-zA-Z0-9 ./'()+&#@]{1,255}$";
+  RegExp regExp = RegExp(pattern);
+
+  if (!regExp.hasMatch(value)) {
+    return 'alphanumeric, space, /, +, -, #, &, @, (), ., only and length 1-255';
+  }
+
+  return null;
+}
+
 String? validateDisplayName(String value) {
   if (value.trim().isEmpty) {
     return 'required';
@@ -988,6 +1004,14 @@ final List<Map<String, dynamic>> listConfigBaseTenantExt = [
     'width': 150,
     'is_mapping_required': false,
     'validator': validateLabelScope,
+  },
+  {
+    'col_key': 'remark',
+    'title': 'Remark',
+    'col_type': 'string',
+    'width': 150,
+    'is_mapping_required': false,
+    'validator': validateTenantLabel,
   },
   // {
   //   'col_key': 'initial_balance',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: buff_helper
 description: "Buff Helper package project"
-version: 2.24.5
+version: 2.24.6
 homepage:
 
 environment:


### PR DESCRIPTION
This pull request introduces a new validation function for remarks and adds a corresponding configuration for a "Remark" field in the tenant extension configuration. The version number is also incremented to reflect these changes.

Validation and configuration updates:

* Added a new `validateRemark` function to check that remarks are either empty or 1-255 characters long and only contain alphanumeric characters, spaces, and specific special characters (`/`, `'`, `+`, `-`, `#`, `&`, `@`, `()`, `.`).
* Added a new configuration entry for the `remark` column in `listConfigBaseTenantExt`, specifying its display properties and validator.

Versioning:

* Updated the package version from `2.24.5` to `2.24.6` in `pubspec.yaml`.