### PR TITLE
add billing contact name validator

### DIFF
--- a/lib/pag_helper/def_helper/dh_pag_tenant.dart
+++ b/lib/pag_helper/def_helper/dh_pag_tenant.dart
@@ -508,9 +508,6 @@ String? validateFloorArea(String value) {
   return null;
 }
 
-String? validateBillingContactName(String value) {
-  return validateFullName(value);
-}
 
 String? validateBillingContactEmail(String value) {
   return validateEmail(value);
@@ -848,7 +845,7 @@ final List<Map<String, dynamic>> listConfigBaseTenantExt = [
     'col_type': 'string',
     'width': 150,
     'is_mapping_required': false,
-    'validator': validateFullName,
+    'validator': validateBillingContactName,
   },
   {
     'col_key': 'billing_email_1',

--- a/lib/up_helper/globals.dart
+++ b/lib/up_helper/globals.dart
@@ -16,6 +16,8 @@ const String glb_reg_allkeyboard =
 const String glb_reg_fullName = r"^[a-zA-Z]{2,}[a-zA-Z-\s]*[a-zA-Z]{2,}$";
 const String glb_fullName_callout = 'Please provide a valid full name';
 const String glb_regNG_fullName = r"[^a-zA-Z '\.]|([.']| )(\.|')|(\s)(\s)";
+const String glb_reg_billing_contact_name =
+    r"^[a-zA-Z]{2,}[a-zA-Z\s\-()/]*[a-zA-Z)]{2,}$";
 // r"^
 // [a-zA-Z0-9-]  //mmatches any character from the alphabet (lowercase or uppercase), digits, or the hyphen symbol
 // {6,} //matches the preceding expression (a character from the alphabet or a hyphen symbol) at least 6 times

--- a/lib/xt_ui/util/xt_util_InputFieldValidator.dart
+++ b/lib/xt_ui/util/xt_util_InputFieldValidator.dart
@@ -51,6 +51,39 @@ String? validateFullName(String? value,
   return result;
 }
 
+String? validateBillingContactName(String? value,
+    {String? emptyCallout, Map<Enum, String?>? formErrors, Enum? filedKey}) {
+  RegExp regex = RegExp(glb_reg_billing_contact_name);
+
+  String? result;
+
+  if (value == null) {
+    result = 'Please enter your full name';
+    if (emptyCallout != null) {
+      result = emptyCallout;
+    }
+  } else {
+    if (value.isEmpty) {
+      result = 'Please enter your full name';
+      if (emptyCallout != null) {
+        result = emptyCallout;
+      }
+    } else {
+      if (!regex.hasMatch(value)) {
+        result = glb_fullName_callout;
+      } else {
+        result = null;
+      }
+    }
+  }
+
+  if (formErrors != null && filedKey != null) {
+    formErrors[filedKey] = result;
+  }
+
+  return result;
+}
+
 String? validateUsername(String? value,
     {Map<Enum, String?>? formErrors, Enum? filedKey}) {
   RegExp regex = RegExp(glb_reg_loginName);
@@ -135,7 +168,7 @@ String? validateEmail(String? value, {String? emptyCallout}) {
 
 String? validateOptionalEmail(String? value) {
   if (value == null || value.trim().isEmpty) {
-    return null; 
+    return null;
   }
 
   final regex = RegExp(glb_reg_email);

--- a/lib/xt_ui/util/xt_util_InputFieldValidator.dart
+++ b/lib/xt_ui/util/xt_util_InputFieldValidator.dart
@@ -58,13 +58,13 @@ String? validateBillingContactName(String? value,
   String? result;
 
   if (value == null) {
-    result = 'Please enter your full name';
+    result = 'Please enter your billing contact name';
     if (emptyCallout != null) {
       result = emptyCallout;
     }
   } else {
     if (value.isEmpty) {
-      result = 'Please enter your full name';
+      result = 'Please enter your billing contact name';
       if (emptyCallout != null) {
         result = emptyCallout;
       }


### PR DESCRIPTION
This pull request introduces a new validator specifically for billing contact names, updates the validation logic and configuration to use this new validator, and defines a new regular expression for billing contact name validation. The main goal is to separate billing contact name validation from the general full name validation, allowing for more precise and appropriate validation rules.

**Validation logic improvements:**

* Added a new function `validateBillingContactName` in `xt_util_InputFieldValidator.dart` to validate billing contact names with a custom regular expression and error handling.
* Updated the validator assignment in the `listConfigBaseTenantExt` configuration to use `validateBillingContactName` instead of the generic `validateFullName`.
* Removed the previous `validateBillingContactName` function in `dh_pag_tenant.dart` that simply called `validateFullName`, as it is now replaced by the dedicated validator.

**Regular expression updates:**

* Added a new constant `glb_reg_billing_contact_name` in `globals.dart` to define the allowed format for billing contact names, which is now used by the new validator.