### PR TITLE
listConfigBaseMeter update

### DIFF
--- a/lib/pag_helper/def_helper/dh_device.dart
+++ b/lib/pag_helper/def_helper/dh_device.dart
@@ -480,7 +480,7 @@ final List<Map<String, dynamic>> listConfigBaseMeter = [
     'title': 'Building Label',
     'col_type': 'string',
     'width': 150,
-    'is_mapping_required': true,
+    'is_mapping_required': false,
     'validator': validateLabelScope,
   },
   {
@@ -488,7 +488,7 @@ final List<Map<String, dynamic>> listConfigBaseMeter = [
     'title': 'Location Label',
     'col_type': 'string',
     'width': 150,
-    'is_mapping_required': true,
+    'is_mapping_required': false,
     'validator': validateLabelScope,
   },
 ];


### PR DESCRIPTION
This pull request makes a small change to the `listConfigBaseMeter` configuration in `lib/pag_helper/def_helper/dh_device.dart`. The change updates the mapping requirements for two fields.

- Set `is_mapping_required` to `false` for both the `building_label` and `location_label` fields, making these fields optional for mapping.